### PR TITLE
feat: 캐릭터 목록 전체 조회 API 구현 - 박찬영

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @Table(name = "avatars")
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -35,7 +35,7 @@ public class Avatar {
     private int grade;
 
     @CreatedDate
-    @Column(nullable = false)
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "avatar", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/domain/Avatar.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @Table(name = "avatars")
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarDto.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarDto.java
@@ -2,7 +2,8 @@ package com.ssafy.solvedpick.avatars.dto;
 
 
 import com.ssafy.solvedpick.avatars.domain.Avatar;
-import com.ssafy.solvedpick.avatars.domain.Grade;
+
+import com.ssafy.solvedpick.common.grade.Grade;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarDto.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarDto.java
@@ -18,20 +18,15 @@ public class AvatarDto {
     private double dropRate; //뽑힐 확률
 
     //Entity를 DTO로 변환하는 메서드
-    public static AvatarDto toDto(Avatar avatar, Map<Integer, Long> countByGrade) {
+    public static AvatarDto from(Avatar avatar, GradeStatistics statistics) {
         Grade grade = Grade.fromValue(avatar.getGrade());
-        // 해당 등급의 전체 캐릭터 수를 가져옴
-        long charactersInGrade = countByGrade.get(avatar.getGrade());
-
-        //개별 캐릭터의 확률을 계산
-        double individualDropRate = grade.getProbability() / charactersInGrade;
 
         //Entity와 Enum의 정보들을 바탕으로 DTO로 변환
         return AvatarDto.builder()
                 .id(String.valueOf(avatar.getId()))
                 .name(avatar.getTitle())
                 .rarity(grade.name())
-                .dropRate(individualDropRate)
+                .dropRate(statistics.getIndividualProbability())
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarDto.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarDto.java
@@ -1,0 +1,37 @@
+package com.ssafy.solvedpick.avatars.dto;
+
+
+import com.ssafy.solvedpick.avatars.domain.Avatar;
+import com.ssafy.solvedpick.avatars.domain.Grade;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class AvatarDto {
+
+    private String id; //API 응답용 ID
+    private String name; //캐릭터 이름
+    private String rarity; //등급 (알파벳)
+    private double dropRate; //뽑힐 확률
+
+    //Entity를 DTO로 변환하는 메서드
+    public static AvatarDto toDto(Avatar avatar, Map<Integer, Long> countByGrade) {
+        Grade grade = Grade.fromValue(avatar.getGrade());
+        // 해당 등급의 전체 캐릭터 수를 가져옴
+        long charactersInGrade = countByGrade.get(avatar.getGrade());
+
+        //개별 캐릭터의 확률을 계산
+        double individualDropRate = grade.getProbability() / charactersInGrade;
+
+        //Entity와 Enum의 정보들을 바탕으로 DTO로 변환
+        return AvatarDto.builder()
+                .id(String.valueOf(avatar.getId()))
+                .name(avatar.getTitle())
+                .rarity(grade.name())
+                .dropRate(individualDropRate)
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarResponse.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarResponse.java
@@ -1,0 +1,21 @@
+package com.ssafy.solvedpick.avatars.dto;
+
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class AvatarResponse {
+    // 리턴해주는 ]son 형식을 맞춰주기 위해 List<AvatarDto> 선언
+    private final List<AvatarDto> avatars;
+
+
+    public AvatarResponse(List<AvatarDto> avatars) {
+        this.avatars = avatars;
+    }
+    //response 생성
+    public static AvatarResponse of(List<AvatarDto> avatars) {
+        return new AvatarResponse(avatars);
+    }
+}

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarResponse.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/AvatarResponse.java
@@ -11,7 +11,7 @@ public class AvatarResponse {
     private final List<AvatarDto> avatars;
 
 
-    public AvatarResponse(List<AvatarDto> avatars) {
+    private AvatarResponse(List<AvatarDto> avatars) {
         this.avatars = avatars;
     }
     //response 생성

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/GradeStatistics.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/GradeStatistics.java
@@ -1,0 +1,19 @@
+package com.ssafy.solvedpick.avatars.dto;
+
+import com.ssafy.solvedpick.avatars.domain.Grade;
+import lombok.Getter;
+
+@Getter
+public class GradeStatistics {
+    private final int grade;
+    private final long count;
+    private final double probability;
+    private final double individualProbability;
+
+    public GradeStatistics(int grade, long count, double probability, double individualProbability)  {
+        this.grade = grade;
+        this.count = count;
+        this.probability = probability;
+        this.individualProbability = individualProbability;
+    }
+}

--- a/src/main/java/com/ssafy/solvedpick/avatars/dto/GradeStatistics.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/dto/GradeStatistics.java
@@ -1,6 +1,6 @@
 package com.ssafy.solvedpick.avatars.dto;
 
-import com.ssafy.solvedpick.avatars.domain.Grade;
+
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/ssafy/solvedpick/avatars/presentation/AvatarController.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/presentation/AvatarController.java
@@ -7,14 +7,16 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/avatar")
 @RequiredArgsConstructor
 public class AvatarController {
     private final AvatarService avatarService;
 
-    @GetMapping("/avatar")
+    @GetMapping
     public ResponseEntity<AvatarResponse> getAllAvatars() {
         AvatarResponse response = avatarService.findAllAvatars();
         return ResponseEntity.ok(response);

--- a/src/main/java/com/ssafy/solvedpick/avatars/presentation/AvatarController.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/presentation/AvatarController.java
@@ -1,0 +1,22 @@
+package com.ssafy.solvedpick.avatars.presentation;
+
+
+import com.ssafy.solvedpick.avatars.dto.AvatarResponse;
+import com.ssafy.solvedpick.avatars.service.AvatarService;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AvatarController {
+    private final AvatarService avatarService;
+
+    @GetMapping("/avatar")
+    public ResponseEntity<AvatarResponse> getAllAvatars() {
+        AvatarResponse response = avatarService.findAllAvatars();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ssafy/solvedpick/avatars/service/AvatarService.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/service/AvatarService.java
@@ -1,0 +1,36 @@
+package com.ssafy.solvedpick.avatars.service;
+
+import com.ssafy.solvedpick.avatars.domain.Avatar;
+import com.ssafy.solvedpick.avatars.dto.AvatarDto;
+import com.ssafy.solvedpick.avatars.dto.AvatarResponse;
+import com.ssafy.solvedpick.avatars.repository.AvatarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AvatarService {
+    private final AvatarRepository avatarRepository;
+
+    public AvatarResponse findAllAvatars() {
+        // 1. 모든 아바타를 가져옵니다.
+        List<Avatar> avatars = avatarRepository.findAll();
+        //2. 등급별 캐릭터 수를 계산합니다.
+        Map<Integer, Long> countByGrade = avatars.stream()
+                .collect(Collectors.groupingBy(
+                        Avatar::getGrade, //등급으로 그룹화
+                        Collectors.counting() // 각 등급별 갯수를 셈
+                ));
+        // 3. Entity들을 DTO로 변환하면서 Map을 전달합니다.
+        List<AvatarDto> avatarDtos = avatars.stream()
+                .map(avatar -> AvatarDto.toDto(avatar, countByGrade))
+                .collect(Collectors.toList());
+
+        //4. 최종 응답 생성
+        return AvatarResponse.of(avatarDtos);
+    }
+}

--- a/src/main/java/com/ssafy/solvedpick/avatars/service/AvatarService.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/service/AvatarService.java
@@ -1,11 +1,12 @@
 package com.ssafy.solvedpick.avatars.service;
 
 import com.ssafy.solvedpick.avatars.domain.Avatar;
-import com.ssafy.solvedpick.avatars.domain.Grade;
+
 import com.ssafy.solvedpick.avatars.dto.AvatarDto;
 import com.ssafy.solvedpick.avatars.dto.AvatarResponse;
 import com.ssafy.solvedpick.avatars.dto.GradeStatistics;
 import com.ssafy.solvedpick.avatars.repository.AvatarRepository;
+import com.ssafy.solvedpick.common.grade.Grade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/ssafy/solvedpick/avatars/service/AvatarService.java
+++ b/src/main/java/com/ssafy/solvedpick/avatars/service/AvatarService.java
@@ -1,12 +1,15 @@
 package com.ssafy.solvedpick.avatars.service;
 
 import com.ssafy.solvedpick.avatars.domain.Avatar;
+import com.ssafy.solvedpick.avatars.domain.Grade;
 import com.ssafy.solvedpick.avatars.dto.AvatarDto;
 import com.ssafy.solvedpick.avatars.dto.AvatarResponse;
+import com.ssafy.solvedpick.avatars.dto.GradeStatistics;
 import com.ssafy.solvedpick.avatars.repository.AvatarRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,18 +22,46 @@ public class AvatarService {
     public AvatarResponse findAllAvatars() {
         // 1. 모든 아바타를 가져옵니다.
         List<Avatar> avatars = avatarRepository.findAll();
-        //2. 등급별 캐릭터 수를 계산합니다.
-        Map<Integer, Long> countByGrade = avatars.stream()
-                .collect(Collectors.groupingBy(
-                        Avatar::getGrade, //등급으로 그룹화
-                        Collectors.counting() // 각 등급별 갯수를 셈
-                ));
-        // 3. Entity들을 DTO로 변환하면서 Map을 전달합니다.
+        //2. 등급별 통계를 계산합니다.
+        List<GradeStatistics> gradeStats = calculateGradeStatistics(avatars);
+        //3. 각 캐릭터를 DTO로 변환하면서 해당 등급의 통계 정보를 함께 전달합니다.
         List<AvatarDto> avatarDtos = avatars.stream()
-                .map(avatar -> AvatarDto.toDto(avatar, countByGrade))
-                .collect(Collectors.toList());
+                .map(avatar -> AvatarDto.from(avatar,
+                        findStatisticsByGrade(gradeStats, avatar.getGrade())
+                )).collect(Collectors.toList());
 
-        //4. 최종 응답 생성
         return AvatarResponse.of(avatarDtos);
+    }
+
+    private List<GradeStatistics> calculateGradeStatistics(List<Avatar> avatars) {
+        List<GradeStatistics> statistics = new ArrayList<>();
+
+
+        for (int grade=1;grade<=5;grade++) {
+            final int currentGrade = grade;
+            long count = avatars.stream().
+                    filter(avatar -> avatar.getGrade() == currentGrade)
+                    .count();
+
+            if (count > 0) {
+                double probability = Grade.fromValue(grade).getProbability();
+                double individualProbability = probability/count;
+                statistics.add(new GradeStatistics(
+                        grade,
+                        count,
+                        probability,
+                        individualProbability
+                ));
+            }
+        }
+        return statistics;
+    }
+
+    private GradeStatistics findStatisticsByGrade(List<GradeStatistics> statistics, int grade) {
+        return statistics.stream()
+                .filter(stat -> stat.getGrade()==grade)
+                .findFirst()
+                .orElseThrow(()-> new IllegalStateException("해당 등급의 통계 정보를 찾을 수 없습니다"));
+
     }
 }

--- a/src/main/java/com/ssafy/solvedpick/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/solvedpick/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configure(http))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/account/verify", "/account/signin", "/account/signup").permitAll()
+                        .requestMatchers("/account/verify", "/account/signin", "/account/signup","/avatar").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(login -> login.disable())


### PR DESCRIPTION
## 💬 Issue Number

## 📝 작업 내용
서비스 메인페이지에서 캐릭터 전체 목록을 볼 수 있도록 캐릭터 목록 전체 조회 API 구현했습니다.
초기 코드 작성 후, 다음과 같이 코드를 수정하였습니다.
-Avatar Entity에서 https://github.com/Setter 제외했습니다.
-주석 제외하였습니다.
-Map 자료구조 대신 클래스와 ArrayList를 사용해서 명확성과 안정성을 높이고자 했습니다.
-확률 계산 로직 부분의 코드를 AvatarService.java로 집중시켰습니다.

## 📷 Screenshots
![pr1](https://github.com/user-attachments/assets/211c0455-379c-4d7f-859e-2958ffd0749a)

## 🚀 학습에 도움을 줄만한 자료
[Map을 사용할 때의 단점](https://mangkyu.tistory.com/164)

## 📒 Remarks

