### PR TITLE
fix: 캐릭터 판매 시 사용자 보유 캐릭터 목록에서 계속 보이는 에러 수정

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/repository/OwnedAvatarRepository.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/repository/OwnedAvatarRepository.java
@@ -18,4 +18,6 @@ public interface OwnedAvatarRepository extends JpaRepository<OwnedAvatar, Long> 
     List<OwnedAvatar> findAllByMemberId(@Param("memberId") Long memberId);
 
     Optional<OwnedAvatar> findById(@Param("ownedAvatarId") Long ownedAvatarId);
+
+    List<OwnedAvatar> findAllByMemberIdAndSoldFalse(Long memberId);
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedavatar/service/impl/OwnedAvatarServiceImpl.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedavatar/service/impl/OwnedAvatarServiceImpl.java
@@ -30,7 +30,7 @@ public class OwnedAvatarServiceImpl implements OwnedAvatarService {
 
     @Override
     public List<OwnedAvatarDTO> getOwnedAvatars(Long memberId) {
-        return ownedAvatarRepository.findAllByMemberId(memberId)
+        return ownedAvatarRepository.findAllByMemberIdAndSoldFalse(memberId)
                 .stream()
                 .map(ownedAvatar -> OwnedAvatarDTO.builder()
                         .visible(ownedAvatar.isVisible())


### PR DESCRIPTION
## 📝 작업 내용
캐릭터 판매 시, 사용자 보유 캐릭터 목록에서 계속 보이는 에러를 수정해서 현재 보유한 캐릭터 목록만 가져오도록 수정했습니다. 
## 📷 Screenshots

> 작업 결과물

## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
