### PR TITLE
fix: gacha 버그 개선 - 이동규

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/gacha/service/GachaService.java
+++ b/src/main/java/com/ssafy/solvedpick/gacha/service/GachaService.java
@@ -13,6 +13,7 @@ import com.ssafy.solvedpick.members.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,10 +32,22 @@ public class GachaService {
     private final Random random = new Random();
     private final AuthService authService;
 
+    @Transactional
     public DrawResponse drawAvatars(int count){
-//        더미 유저
+
         Member member = authService.getCurrentMember();
 
+        if (count != 1 && count != 10) {
+            throw new IllegalArgumentException("가챠는 1회 또는 10회만 가능합니다.");
+        }
+
+        int totalCost = count * DRAW_COST;
+        if (member.getPoint() < totalCost) {
+            throw new IllegalArgumentException("포인트가 부족합니다. 필요 포인트: " + totalCost + ", 보유 포인트: " + member.getPoint());
+        }
+
+        member.usePoint(totalCost);
+        this.memberRepository.save(member);
         List<DrawAvatarDto> results = new ArrayList<>();
 
         for(int i=0; i<count; i++){
@@ -62,8 +75,7 @@ public class GachaService {
                     .dropRate(Grade.fromValue(selectedAvatar.getGrade()).getProbability())
                     .build());
         }
-        member.usePoint(count * DRAW_COST);
-        this.memberRepository.save(member);
+
         return DrawResponse.builder()
                 .avatars(results)
                 .build();


### PR DESCRIPTION
## 📝 작업 내용
- transactional 처리
- count가 1이나 10 이외의 숫자일 경우 에러 반환
- 유저 보유 포인트가 총 필요 포인트보다 적을 경우 에러 반환
## 📷 Screenshots

## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks
- 외부 postman으로 count를 임의의 값으로 넣어 요청이 가능하다고 하여 임시 방편으로 bugfix합니다.
- 추후 리팩토링을 통해 개선해야 할 여지가 있습니다.