### PR TITLE
fix: 쿼리 조건문 변경 - famo1245

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/ssafy/solvedpick/auction/repository/AuctionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
@@ -35,4 +36,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             "WHERE a.ownedAvatar.member.id = :memberId " +
             "ORDER BY a.createdAt DESC")
     List<Auction> findAllByMember(@Param("memberId") Long memberId);
+
+    @EntityGraph(attributePaths = {"ownedAvatar", "ownedAvatar.avatar", "ownedAvatar.member"})
+    Optional<Auction> findByIdAndSoldFalseAndCancelledFalse(long id);
 }

--- a/src/main/java/com/ssafy/solvedpick/auction/service/AuctionService.java
+++ b/src/main/java/com/ssafy/solvedpick/auction/service/AuctionService.java
@@ -62,7 +62,7 @@ public class AuctionService {
     }
 
     public Auction buyAvatar(Long id) {
-        Auction auction = auctionRepository.findById(id)
+        Auction auction = auctionRepository.findByIdAndSoldFalseAndCancelledFalse(id)
                 .orElseThrow(() -> new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         auction.sold();
 


### PR DESCRIPTION
## 📝 작업 내용

- 경매장 id로 요청온 엔티티 검색 시 취소 여부와 판매 여부를 확인하지 않아 판매되거나 취소된 매물이 요청 성공하는 버그 수정
