### PR TITLE
feat: 사용자 소유 배경화면 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/dto/OwnedBackgroundDTO.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/dto/OwnedBackgroundDTO.java
@@ -1,0 +1,16 @@
+package com.ssafy.solvedpick.ownedbackgrounds.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnedBackgroundDTO {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/dto/OwnedBackgroundResponse.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/dto/OwnedBackgroundResponse.java
@@ -1,0 +1,17 @@
+package com.ssafy.solvedpick.ownedbackgrounds.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnedBackgroundResponse {
+
+    private List<OwnedBackgroundDTO> backgrounds;
+
+}

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/presentation/OwnedBackgroundController.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/presentation/OwnedBackgroundController.java
@@ -1,10 +1,25 @@
 package com.ssafy.solvedpick.ownedbackgrounds.presentation;
 
+import com.ssafy.solvedpick.auth.service.AuthService;
+import com.ssafy.solvedpick.members.domain.Member;
+import com.ssafy.solvedpick.ownedbackgrounds.dto.OwnedBackgroundResponse;
+import com.ssafy.solvedpick.ownedbackgrounds.service.OwnedBackgroundService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
+@RequestMapping("/background/owned")
 @RequiredArgsConstructor
 public class OwnedBackgroundController {
 
+    private final OwnedBackgroundService ownedBackgroundService;
+    private final AuthService authService;
+
+    @GetMapping()
+    public ResponseEntity<?> getOwnedBackgrounds() {
+        Member member = authService.getCurrentMember();
+        OwnedBackgroundResponse response = ownedBackgroundService.getOwnedBackgrounds(member);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/repository/OwnedBackgroundRepository.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/repository/OwnedBackgroundRepository.java
@@ -4,10 +4,12 @@ import com.ssafy.solvedpick.members.domain.Member;
 import com.ssafy.solvedpick.ownedbackgrounds.domain.OwnedBackground;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OwnedBackgroundRepository extends JpaRepository<OwnedBackground, Long> {
 
     Optional<OwnedBackground> findByMemberAndVisibleTrue(Member member);
 
+    List<OwnedBackground> findAllByMember(Member member);
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/service/OwnedBackgroundService.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/service/OwnedBackgroundService.java
@@ -1,10 +1,36 @@
 package com.ssafy.solvedpick.ownedbackgrounds.service;
 
+import com.ssafy.solvedpick.members.domain.Member;
+import com.ssafy.solvedpick.ownedbackgrounds.domain.OwnedBackground;
+import com.ssafy.solvedpick.ownedbackgrounds.dto.OwnedBackgroundDTO;
+import com.ssafy.solvedpick.ownedbackgrounds.dto.OwnedBackgroundResponse;
+import com.ssafy.solvedpick.ownedbackgrounds.repository.OwnedBackgroundRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class OwnedBackgroundService {
 
+    private final OwnedBackgroundRepository ownedBackgroundRepository;
+
+    @Transactional(readOnly = true)
+    public OwnedBackgroundResponse getOwnedBackgrounds(Member member) {
+
+        List<OwnedBackground> backgrounds = ownedBackgroundRepository.findAllByMember(member);
+
+        List<OwnedBackgroundDTO> backgroundDTOS = backgrounds.stream()
+                .map(background -> OwnedBackgroundDTO.builder()
+                        .id(background.getId())
+                        .name(background.getBackground().getName())
+                        .build())
+                .toList();
+
+        return OwnedBackgroundResponse.builder()
+                .backgrounds(backgroundDTOS)
+                .build();
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 사용자가 소유한 배경화면 목록 조회 엔드포인트 추가
- OwnedBackgroundDTO, OwnedBackgroundResponse 구현
- 사용자별 소유 배경화면 조회 로직 구현
## 📷 Screenshots

<img width="415" alt="image" src="https://github.com/user-attachments/assets/7f6ac25c-8ad2-4a19-86e3-f1c6af6be28b" />

## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks

