### PR TITLE
feat: 배경화면 활성화 상태 변경 API 구현 - 이동규

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/domain/OwnedBackground.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/domain/OwnedBackground.java
@@ -38,4 +38,8 @@ public class OwnedBackground {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public void updateVisibility(){
+        this.visible = !this.visible;
+    }
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/presentation/OwnedBackgroundController.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/presentation/OwnedBackgroundController.java
@@ -22,4 +22,11 @@ public class OwnedBackgroundController {
         OwnedBackgroundResponse response = ownedBackgroundService.getOwnedBackgrounds(member);
         return ResponseEntity.ok(response);
     }
+
+    @PatchMapping("/{backgroundId}")
+    public ResponseEntity<?> updateOwnedBackground(@PathVariable Long backgroundId) {
+        Member member = authService.getCurrentMember();
+        ownedBackgroundService.updateBackgroundVisibility(member, backgroundId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/repository/OwnedBackgroundRepository.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/repository/OwnedBackgroundRepository.java
@@ -15,4 +15,6 @@ public interface OwnedBackgroundRepository extends JpaRepository<OwnedBackground
     List<OwnedBackground> findAllByMember(Member member);
 
     Boolean existsByMemberAndBackground(Member member, Background background);
+
+    Optional<OwnedBackground> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/service/OwnedBackgroundService.java
+++ b/src/main/java/com/ssafy/solvedpick/ownedbackgrounds/service/OwnedBackgroundService.java
@@ -6,8 +6,10 @@ import com.ssafy.solvedpick.ownedbackgrounds.dto.OwnedBackgroundDTO;
 import com.ssafy.solvedpick.ownedbackgrounds.dto.OwnedBackgroundResponse;
 import com.ssafy.solvedpick.ownedbackgrounds.repository.OwnedBackgroundRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.List;
 
@@ -32,5 +34,17 @@ public class OwnedBackgroundService {
         return OwnedBackgroundResponse.builder()
                 .backgrounds(backgroundDTOS)
                 .build();
+    }
+
+    @Transactional
+    public void updateBackgroundVisibility(Member member, Long backgroundId) {
+
+        ownedBackgroundRepository.findByMemberAndVisibleTrue(member)
+                .ifPresent(OwnedBackground::updateVisibility);
+
+        OwnedBackground newBackground = ownedBackgroundRepository.findByIdAndMember(backgroundId, member)
+                .orElseThrow(() -> new HttpClientErrorException(HttpStatus.NOT_FOUND, "소유하지 않은 배경입니다."));
+
+        newBackground.updateVisibility();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

- 사용자가 소유한 배경화면의 활성화 상태 변경 엔드포인트 추가
- OwnedBackground 엔티티에 visible 상태 토글 메서드 추가
- 한 사용자가 동시에 하나의 배경화면만 활성화할 수 있도록 제어

## 📷 Screenshots

## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks
