### PR TITLE
Fix: JWT 미처리 로직 추가

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/solvedpick/common/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -22,11 +23,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;
     }
-
+    
+    private static final Set<String> PERMIT_ALL_PATHS = Set.of(
+    		"/account/verify",
+            "/account/signin",
+            "/account/signout",
+            "/account/signup",
+            "/account/password/find",
+            "/jwt/reissue",
+            "/avatar",
+            "/compose/**",
+            "/favicon.ico",
+            "/user/me/extension"
+    );
+    
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-    	if (request.getRequestURI().equals("/jwt/reissue")) {
+    	if (PERMIT_ALL_PATHS.contains(request.getRequestURI())) {
     	        filterChain.doFilter(request, response);
     	        return;
     	    }


### PR DESCRIPTION
## 💬 Issue Number

## 📝 작업 내용
예를 들어 로그인 시에 token이 필요하지 않지만 만료된 token이 있을 경우 로그인이 거절되는 현상
- 원래 요청에는 header에 담아 보내면 안 되지만 Front에서는 token이 존재하면 무조건 담아서 요청을 보내는 상황)

미처리하는 path를 설정하여 통과하도록 설정
## 📷 Screenshots


## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
