### PR TITLE
feat: 이미지 투표 및 투표수 조회 기능 추가 - 이동규

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/image/domain/Image.java
+++ b/src/main/java/com/ssafy/solvedpick/image/domain/Image.java
@@ -31,6 +31,10 @@ public class Image {
     @Column(name = "visible")
     private Boolean visible=false;
 
+    @Builder.Default
+    @Column(name = "vote_count")
+    private Integer voteCount=0;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -39,5 +43,7 @@ public class Image {
     @JoinColumn(name = "member_id")
     private Member member;
 
-
+    public void updateVoteCount() {
+        this.voteCount++;
+    }
 }

--- a/src/main/java/com/ssafy/solvedpick/image/dto/ImageCountDTO.java
+++ b/src/main/java/com/ssafy/solvedpick/image/dto/ImageCountDTO.java
@@ -1,0 +1,14 @@
+package com.ssafy.solvedpick.image.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageCountDTO {
+    private Long imageId;
+    private Integer count;
+}

--- a/src/main/java/com/ssafy/solvedpick/image/dto/ImageCountResponse.java
+++ b/src/main/java/com/ssafy/solvedpick/image/dto/ImageCountResponse.java
@@ -1,0 +1,15 @@
+package com.ssafy.solvedpick.image.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageCountResponse {
+    private List<ImageCountDTO> voteCounts;
+}

--- a/src/main/java/com/ssafy/solvedpick/image/presentation/ImageController.java
+++ b/src/main/java/com/ssafy/solvedpick/image/presentation/ImageController.java
@@ -2,6 +2,7 @@ package com.ssafy.solvedpick.image.presentation;
 
 import com.ssafy.solvedpick.auth.service.AuthService;
 import com.ssafy.solvedpick.image.dto.ContestImageResponse;
+import com.ssafy.solvedpick.image.dto.ImageCountResponse;
 import com.ssafy.solvedpick.image.dto.ImageSaveRequest;
 import com.ssafy.solvedpick.image.service.ImageService;
 import com.ssafy.solvedpick.members.domain.Member;
@@ -44,4 +45,18 @@ public class ImageController {
         ContestImageResponse images = imageService.findContestImages();
         return ResponseEntity.ok(images);
     }
+
+    @PatchMapping("/vote/{imageId}")
+    public ResponseEntity<?> voteImage(@PathVariable Long imageId) {
+        Member member =  authService.getCurrentMember();
+        imageService.voteImage(member, imageId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/votes")
+    public ResponseEntity<ImageCountResponse> getVoteCount() {
+        ImageCountResponse votes = imageService.getVoteCount();
+        return ResponseEntity.ok(votes);
+    }
+
 }

--- a/src/main/java/com/ssafy/solvedpick/image/service/ImageService.java
+++ b/src/main/java/com/ssafy/solvedpick/image/service/ImageService.java
@@ -1,9 +1,7 @@
 package com.ssafy.solvedpick.image.service;
 
 import com.ssafy.solvedpick.image.domain.Image;
-import com.ssafy.solvedpick.image.dto.ContestImageDTO;
-import com.ssafy.solvedpick.image.dto.ContestImageResponse;
-import com.ssafy.solvedpick.image.dto.ImageSaveRequest;
+import com.ssafy.solvedpick.image.dto.*;
 import com.ssafy.solvedpick.image.repository.ImageRepository;
 import com.ssafy.solvedpick.members.domain.Member;
 import com.ssafy.solvedpick.image.dto.PresignedUrlResponse;
@@ -11,13 +9,17 @@ import com.ssafy.solvedpick.s3.service.S3Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -25,6 +27,10 @@ import java.util.Set;
 public class ImageService {
     private final S3Service s3Service;
     private final ImageRepository imageRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String VOTE_KEY_PREFIX = "vote:";
+    private static final LocalDateTime CONTEST_END_DATE = LocalDateTime.of(2025, 2, 22, 0, 0, 0);
 
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
             "image/png",
@@ -88,6 +94,44 @@ public class ImageService {
 
         return ContestImageResponse.builder()
                 .images(images)
+                .build();
+    }
+
+    @Transactional
+    public void voteImage(Member member, Long imageId) {
+        String key = VOTE_KEY_PREFIX + member.getId() + ":" + imageId;
+        Duration timeUntilEnd = Duration.between(LocalDateTime.now(), CONTEST_END_DATE);
+
+        if(timeUntilEnd.isNegative()){
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "투표가 마감되었습니다.");
+        }
+
+        Boolean isFirstVote = redisTemplate.opsForValue()
+                .setIfAbsent(key, "voted", timeUntilEnd.toSeconds(), TimeUnit.SECONDS);
+
+        if (Boolean.FALSE.equals(isFirstVote)) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "이미 투표한 이미지입니다.");
+        }
+
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new HttpClientErrorException(
+                        HttpStatus.NOT_FOUND,
+                        "해당 이미지가 존재하지 않습니다."
+                ));
+        image.updateVoteCount();
+    }
+
+    public ImageCountResponse getVoteCount() {
+        List<ImageCountDTO> voteCounts = imageRepository.findImageByVisibleTrue()
+                .stream()
+                .map(image -> ImageCountDTO.builder()
+                        .imageId(image.getId())
+                        .count(image.getVoteCount())
+                        .build())
+                .toList();
+
+        return ImageCountResponse.builder()
+                .voteCounts(voteCounts)
                 .build();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 한 번 투표한 이미지에 동일한 사용자가 재투표 못하도록 구현
- 투표 기간 만료 후 투표하지 못하도록 구현
- 이미지 전체 투표수 조회 기능 추가

## 📷 Screenshots

![image](https://github.com/user-attachments/assets/9f3635a6-1006-4954-b9ef-e6d8df6add98)

## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks
- db 변경이 있습니다.