### PR TITLE
fix: 사용자 정보 업데이트 스케쥴러 조정

### DIFF
--- a/src/main/java/com/ssafy/solvedpick/members/scheduler/UserInfoScheduler.java
+++ b/src/main/java/com/ssafy/solvedpick/members/scheduler/UserInfoScheduler.java
@@ -24,7 +24,7 @@ public class UserInfoScheduler {
         List<Long> memberIds = memberRepository.findAllIds();  // ID만 조회
         log.info("scheduled update start, size: {}", memberIds.size());
 
-        int batchSize = 100;
+        int batchSize = 50;
         for (int i = 0; i < memberIds.size(); i += batchSize) {
             int end = Math.min(i + batchSize, memberIds.size());
             List<Long> batchIds = memberIds.subList(i, end);
@@ -32,7 +32,7 @@ public class UserInfoScheduler {
             for (Long memberId : batchIds) {
                 try {
                     memberService.updateUserProcess(memberId);
-                    Thread.sleep(200);
+                    Thread.sleep(5000);
                 } catch (Exception e) {
                     log.error("Failed to update user: {}", memberId, e);
                 }


### PR DESCRIPTION
## 📝 작업 내용
- 배치 크기를 100명에서 50명으로 축소
- 개별 사용자 업데이트 간 지연 시간을 200ms에서 5초로 증가
- 배치 간 60초 지연 시간 유지

## 📷 Screenshots

## 🚀 학습에 도움을 줄만한 자료

## 📒 Remarks
- 500명 사용자 기준 약 1시간 걸리도록 조정했습니다. 가장 큰 문제는 간격을 늘리더라도 정보 업데이트가 일정 시간 내에 완료되어야 출석 체크 기능이 정상 동작할 수 있는데 추후 이용자가 더 늘어난다면 한계가 발생할 것으로 예상되어 좀 더 고민이 필요할 것 같습니다.
